### PR TITLE
fixed docker compose + added python example connection with DSN

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,27 @@
-version: '3'
+version: '3.9'
+
+x-restart-always: &restart-always
+  restart: always
 
 services:
   rabbitmq:
     image: rabbitmq:${RABBITMQ_IMAGE_VERSION}
-      hostname: rabbitmq
-      security_opt:
-        - no-new-privileges:true
-      <<: *restart-always
-      environment:
-        RABBITMQ_DEFAULT_USER: ${MESSENGER_TRANSPORT_USER}
-        RABBITMQ_DEFAULT_PASS: ${MESSENGER_TRANSPORT_SECRET}
-      expose:
-        - 5672
-        - 15672
-      volumes:
-        - ./docker/rabbitmq/definitions.json:/etc/rabbitmq/definitions.json
-        - ./docker/rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
-        - rabbitmq_data:/var/lib/rabbitmq
-        networks:
-          - proxy
+    hostname: rabbitmq
+    security_opt:
+      - no-new-privileges:true
+    <<: *restart-always
+    environment:
+      RABBITMQ_DEFAULT_USER: ${MESSENGER_TRANSPORT_USER}
+      RABBITMQ_DEFAULT_PASS: ${MESSENGER_TRANSPORT_SECRET}
+    ports:
+      - "5673:5672"
+      - "15673:15672"
+    volumes:
+      - ./docker/rabbitmq/definitions.json:/etc/rabbitmq/definitions.json
+      - ./docker/rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
+      - rabbitmq_data:/var/lib/rabbitmq
+    networks:
+      - proxy
 
 volumes:
   rabbitmq_data:

--- a/test.py
+++ b/test.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+import pika
+
+connection = pika.BlockingConnection(pika.connection.URLParameters('amqp://default:password@localhost:5673/%2f/messages'))
+channel = connection.channel()
+channel.queue_declare(queue='messages_normal')
+channel.basic_publish(exchange='', routing_key='hello', body='Hello World!')
+print(" [x] Sent 'Hello World!'")
+connection.close()


### PR DESCRIPTION
Fixed docker-compose config + added `test.py` with DSN as example